### PR TITLE
Nse exchange again changed the data path from 1.1.2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+##### Fixes have been made to the Derby database  
+Find the updated version here: https://github.com/virresh/nseeod/releases/tag/v3.3.1
+
+
+Original Description:  
+
 # nseeod
 NSE EOD Data Downloader was built out of my frustration of not getting valid free stock price data at the tip of my hands, and sharing this project has only made lives easier for people like me who are interested in analyzing stock price data.
 

--- a/src/commonfunctions/CommonFunctions.java
+++ b/src/commonfunctions/CommonFunctions.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/commonfunctions/Constants.java
+++ b/src/commonfunctions/Constants.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/commonfunctions/FileUtil.java
+++ b/src/commonfunctions/FileUtil.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/config/ConfigRW.java
+++ b/src/config/ConfigRW.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/config/ConfigSettings.java
+++ b/src/config/ConfigSettings.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/config/configxml/CheckBox.java
+++ b/src/config/configxml/CheckBox.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/config/configxml/CheckBoxHolder.java
+++ b/src/config/configxml/CheckBoxHolder.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/config/configxml/Settings.java
+++ b/src/config/configxml/Settings.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/config/configxml/download/Download.java
+++ b/src/config/configxml/download/Download.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/config/configxml/download/DownloadPanelBase.java
+++ b/src/config/configxml/download/DownloadPanelBase.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/config/configxml/others/Others.java
+++ b/src/config/configxml/others/Others.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/convertcsv/ConvertCurrFut.java
+++ b/src/convertcsv/ConvertCurrFut.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/convertcsv/ConvertEQ.java
+++ b/src/convertcsv/ConvertEQ.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/convertcsv/ConvertFO.java
+++ b/src/convertcsv/ConvertFO.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/convertcsv/ConvertFile.java
+++ b/src/convertcsv/ConvertFile.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/convertcsv/ConvertIndices.java
+++ b/src/convertcsv/ConvertIndices.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/db/DBConnection.java
+++ b/src/db/DBConnection.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 
@@ -34,6 +35,7 @@ class DBConnection {
 	private static void initDataSource(){
 		EmbeddedConnectionPoolDataSource40 ecps=new EmbeddedConnectionPoolDataSource40();
 		ecps.setDatabaseName(System.getProperty("user.dir")+"/nsedb");
+		ecps.setCreateDatabase("create");
 		ecps.setUser("nseeod");
 		ecps.setPassword("nseeod");
 		ds=ecps;
@@ -43,7 +45,10 @@ class DBConnection {
 	//connections are not fetched frequently. Hence avoiding double checked locking or similar optimization
 	public static synchronized Connection getConnection() throws SQLException{
 		if(ds==null)
+		{
 			initDataSource();
+//			System.out.print(ds.getConnection().isClosed() + "\n");
+		}
 		return ds.getConnection();
 	}
 }

--- a/src/db/DBExecutor.java
+++ b/src/db/DBExecutor.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 
@@ -209,6 +210,7 @@ public class DBExecutor {
 			DBConnection.getConnection().close();
 		}
 		catch(SQLException e){
+			System.out.print(e);
 			if(e.getNextException().getMessage().contains("Another instance of Derby may have already booted the database"))
 				value= true;
 		}

--- a/src/db/Queries.java
+++ b/src/db/Queries.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/downloadfiles/CurrencyFuturesFiles.java
+++ b/src/downloadfiles/CurrencyFuturesFiles.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/downloadfiles/DownloadFile.java
+++ b/src/downloadfiles/DownloadFile.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 
@@ -160,6 +161,7 @@ public class DownloadFile {
 		else if(type.equals("cmprzip")){
 			generateURL=String.format(baseURLs.getPrimaryLink().appendEndURL(links.getOtherReportsLink()),CommonFunctions.getStringToDate(date, CommonFunctions.DDMMYYYYhifenFormat));
 		}
+		System.out.println(generateURL);
 		downloadFile(generateURL, outputDir, fileNameWithExtension, requestPropertyMap);
 		outputFile = new File(outputDir+fileNameWithExtension);
 		logger.log("Completed zip download");

--- a/src/downloadfiles/DownloadFileThread.java
+++ b/src/downloadfiles/DownloadFileThread.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 
@@ -29,7 +30,7 @@ import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.List;
 
-import com.sun.org.apache.xalan.internal.xsltc.compiler.sym;
+//import com.sun.org.apache.xalan.internal.xsltc.compiler.sym;
 
 import logging.Logging;
 import commonfunctions.CommonFunctions;

--- a/src/downloadfiles/DownloadFilesListener.java
+++ b/src/downloadfiles/DownloadFilesListener.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/downloadfiles/EquityFiles.java
+++ b/src/downloadfiles/EquityFiles.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/downloadfiles/FuturesFiles.java
+++ b/src/downloadfiles/FuturesFiles.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/downloadfiles/IndexFiles.java
+++ b/src/downloadfiles/IndexFiles.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/downloadfiles/OptionsFiles.java
+++ b/src/downloadfiles/OptionsFiles.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/downloadfiles/OtherFiles.java
+++ b/src/downloadfiles/OtherFiles.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/dto/BaseURLs.java
+++ b/src/dto/BaseURLs.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/dto/CheckUpdatesDTO.java
+++ b/src/dto/CheckUpdatesDTO.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/dto/IndexSymbol.java
+++ b/src/dto/IndexSymbol.java
@@ -1,3 +1,25 @@
+/*
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
+
+The program is distributed under the terms of the GNU General Public License
+
+This file is part of NSE EOD Data Downloader.
+
+NSE EOD Data Downloader is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+NSE EOD Data Downloader is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with NSE EOD Data Downloader.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package dto;
 
 public class IndexSymbol {

--- a/src/dto/Links.java
+++ b/src/dto/Links.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/dto/ValidationDTO.java
+++ b/src/dto/ValidationDTO.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/exceptionhandler/ExceptionHandler.java
+++ b/src/exceptionhandler/ExceptionHandler.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/logging/DisplayLogMessageListener.java
+++ b/src/logging/DisplayLogMessageListener.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/logging/LogFormatter.java
+++ b/src/logging/LogFormatter.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/logging/Logging.java
+++ b/src/logging/Logging.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/maingui/Details.java
+++ b/src/maingui/Details.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/maingui/GUI.java
+++ b/src/maingui/GUI.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/maingui/Marquee.java
+++ b/src/maingui/Marquee.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/maingui/Notice.java
+++ b/src/maingui/Notice.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/maingui/NseEOD.java
+++ b/src/maingui/NseEOD.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/testconnection/CheckNews.java
+++ b/src/testconnection/CheckNews.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/testconnection/CheckNewsListener.java
+++ b/src/testconnection/CheckNewsListener.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/testconnection/CheckUpdates.java
+++ b/src/testconnection/CheckUpdates.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/testconnection/CheckUpdatesListener.java
+++ b/src/testconnection/CheckUpdatesListener.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/testconnection/DateValidation.java
+++ b/src/testconnection/DateValidation.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/testconnection/ValidateConnection.java
+++ b/src/testconnection/ValidateConnection.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/testconnection/ValidateConnectionListener.java
+++ b/src/testconnection/ValidateConnectionListener.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 

--- a/src/unzipfiles/UnzipFiles.java
+++ b/src/unzipfiles/UnzipFiles.java
@@ -1,5 +1,6 @@
 /*
-Copyright (c) 2011,2012,2013,2014 Rohit Jhunjhunwala
+Author: Rohit Jhunjhunwala (2011-2016)
+Modified by: Viresh Gupta (@virresh)
 
 The program is distributed under the terms of the GNU General Public License
 


### PR DESCRIPTION
Hi viresh the exchange again changed their data path from 1.1.2021 .so. the downloader for nse date not downloadable.date from serverpls do the needful
Thanks